### PR TITLE
Integrate ollama-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7951,6 +7951,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ollama": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.16.tgz",
+      "integrity": "sha512-OEbxxOIUZtdZgOaTPAULo051F5y+Z1vosxEYOoABPnQKeW7i4O8tJNlxCB+xioyoorVqgjkdj+TA1f1Hy2ug/w==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-fetch": "^3.6.20"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11183,6 +11192,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -11764,6 +11779,7 @@
         "html-to-text": "^9.0.5",
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
+        "ollama": "^0.5.16",
         "open": "^10.1.2",
         "shell-quote": "^1.8.2",
         "simple-git": "^3.28.0",

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -20,6 +20,10 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_OLLAMA) {
+    return null;
+  }
+
   if (authMethod === AuthType.USE_VERTEX_AI) {
     const hasVertexProjectLocationConfig =
       !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GOOGLE_CLOUD_LOCATION;

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -35,6 +35,7 @@ export function AuthDialog({
     },
     { label: 'Gemini API Key (AI Studio)', value: AuthType.USE_GEMINI },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'Ollama (local)', value: AuthType.USE_OLLAMA },
   ];
 
   let initialAuthIndex = items.findIndex(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "html-to-text": "^9.0.5",
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
+    "ollama": "^0.5.16",
     "open": "^10.1.2",
     "shell-quote": "^1.8.2",
     "simple-git": "^3.28.0",

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -13,6 +13,7 @@ import {
   EmbedContentParameters,
   GoogleGenAI,
 } from '@google/genai';
+import { OllamaContentGenerator } from './ollamaContentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { getEffectiveModel } from './modelCheck.js';
@@ -38,6 +39,7 @@ export enum AuthType {
   LOGIN_WITH_GOOGLE_PERSONAL = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
+  USE_OLLAMA = 'ollama',
 }
 
 export type ContentGeneratorConfig = {
@@ -45,6 +47,7 @@ export type ContentGeneratorConfig = {
   apiKey?: string;
   vertexai?: boolean;
   authType?: AuthType | undefined;
+  host?: string;
 };
 
 export async function createContentGeneratorConfig(
@@ -56,6 +59,7 @@ export async function createContentGeneratorConfig(
   const googleApiKey = process.env.GOOGLE_API_KEY;
   const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION;
+  const ollamaHost = process.env.OLLAMA_HOST;
 
   // Use runtime model from config if available, otherwise fallback to parameter or default
   const effectiveModel = config?.getModel?.() || model || DEFAULT_GEMINI_MODEL;
@@ -67,6 +71,11 @@ export async function createContentGeneratorConfig(
 
   // if we are using google auth nothing else to validate for now
   if (authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+    return contentGeneratorConfig;
+  }
+
+  if (authType === AuthType.USE_OLLAMA) {
+    contentGeneratorConfig.host = ollamaHost;
     return contentGeneratorConfig;
   }
 
@@ -123,6 +132,10 @@ export async function createContentGenerator(
     });
 
     return googleGenAI.models;
+  }
+
+  if (config.authType === AuthType.USE_OLLAMA) {
+    return new OllamaContentGenerator(config.host);
   }
 
   throw new Error(

--- a/packages/core/src/core/ollamaContentGenerator.ts
+++ b/packages/core/src/core/ollamaContentGenerator.ts
@@ -1,0 +1,80 @@
+import ollama, { Ollama } from 'ollama';
+import {
+  GenerateContentParameters,
+  GenerateContentResponse,
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+  Content,
+} from '@google/genai';
+import { ContentGenerator } from './contentGenerator.js';
+
+export class OllamaContentGenerator implements ContentGenerator {
+  private client: Ollama
+  constructor(host?: string) {
+    this.client = host ? new Ollama({ host }) : (ollama as unknown as Ollama)
+  }
+
+  private contentsToMessages(contents: Content[]) {
+    return contents.map((c) => {
+      const text = c.parts?.map((p: any) => p.text ?? '').join('') ?? ''
+      const role = c.role === 'user' ? 'user' : 'assistant'
+      return { role, content: text }
+    })
+  }
+
+  async generateContent(
+    request: GenerateContentParameters,
+  ): Promise<GenerateContentResponse> {
+    const messages = this.contentsToMessages(request.contents as Content[])
+    const response = await this.client.chat({
+      model: request.model,
+      messages,
+    })
+    return {
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [{ text: (response as any).message.content }],
+          } as Content,
+        },
+      ],
+    } as GenerateContentResponse
+  }
+
+  async generateContentStream(
+    request: GenerateContentParameters,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    const messages = this.contentsToMessages(request.contents as Content[])
+    const stream = await this.client.chat({
+      model: request.model,
+      messages,
+      stream: true,
+    })
+    const gen = async function* (s: AsyncGenerator<any>): AsyncGenerator<GenerateContentResponse> {
+      for await (const part of s) {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: part.message.content }],
+              } as Content,
+            },
+          ],
+        } as GenerateContentResponse
+      }
+    }
+    return gen(stream as AsyncGenerator<any>)
+  }
+
+  async countTokens(_: CountTokensParameters): Promise<CountTokensResponse> {
+    return { totalTokens: 0 }
+  }
+
+  async embedContent(_: EmbedContentParameters): Promise<EmbedContentResponse> {
+    return { embeddings: [] }
+  }
+}


### PR DESCRIPTION
## Summary
- add `OllamaContentGenerator` using the `ollama` library
- support `USE_OLLAMA` auth type
- add Ollama auth option in the UI and validation
- update dependencies for `ollama`

## Testing
- `npm test` *(fails: cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_685f1fa977d48325806a60dc278f18ed